### PR TITLE
feat: Notify user when collector version is out of date

### DIFF
--- a/bindays_app/lib/client/client_with_retry.dart
+++ b/bindays_app/lib/client/client_with_retry.dart
@@ -4,6 +4,9 @@ import 'package:bindays_client/models/address.dart';
 import 'package:bindays_client/models/bin_day.dart';
 import 'package:bindays_client/models/collector.dart';
 
+// Internal Imports
+import 'package:bindays_app/misc/collector_version_error.dart';
+
 /// [ClientWithRetry] wraps the [Client] class methods providing additional retry mechanism on failure.
 class ClientWithRetry {
   final Client _client;
@@ -16,7 +19,9 @@ class ClientWithRetry {
       try {
         return await function.call();
       } catch (e) {
-        if (i == retryCount) {
+        // A 410 means the collector version is permanently out of date —
+        // retrying will always fail until the user re-selects their address.
+        if (isCollectorVersionOutdated(e) || i == retryCount) {
           rethrow;
         }
       }

--- a/bindays_app/lib/data/background_task_manager.dart
+++ b/bindays_app/lib/data/background_task_manager.dart
@@ -6,7 +6,9 @@ import 'package:timezone/data/latest.dart' as tz;
 
 // Internal Imports
 import 'package:bindays_app/client/bindays_client.dart';
+import 'package:bindays_app/data/notifications_manager.dart';
 import 'package:bindays_app/data/shared_preferences_manager.dart';
+import 'package:bindays_app/misc/collector_version_error.dart';
 import 'package:bindays_app/notifiers/global_notifiers.dart';
 
 @pragma('vm:entry-point')
@@ -68,13 +70,23 @@ class BackgroundTaskManager {
       return;
     }
 
-    final binDays = await binDaysClient.getBinDays(
-      globalStateNotifier.collector!,
-      globalStateNotifier.address!,
-    );
-    globalStateNotifier.setBinDays(binDays);
-    globalStateNotifier.setLastRefresh(DateTime.now());
+    try {
+      final binDays = await binDaysClient.getBinDays(
+        globalStateNotifier.collector!,
+        globalStateNotifier.address!,
+      );
+      globalStateNotifier.setBinDays(binDays);
+      globalStateNotifier.setLastRefresh(DateTime.now());
+    } catch (e) {
+      if (isCollectorVersionOutdated(e)) {
+        // init() is called here because in headless mode the notification
+        // plugin may not have been initialised by the normal app startup path.
+        await NotificationsManager.init();
+        await NotificationsManager.showCollectorUpdateNotification();
+      }
+    }
   }
+
 }
 
 // [Android-only] This "Headless Task" is run when the Android app is terminated with `enableHeadless: true`

--- a/bindays_app/lib/data/background_task_manager.dart
+++ b/bindays_app/lib/data/background_task_manager.dart
@@ -81,8 +81,12 @@ class BackgroundTaskManager {
       if (isCollectorVersionOutdated(e)) {
         // init() is called here because in headless mode the notification
         // plugin may not have been initialised by the normal app startup path.
-        await NotificationsManager.init();
+        // requestPermissions: false avoids triggering a permission dialog from
+        // a background context.
+        await NotificationsManager.init(requestPermissions: false);
         await NotificationsManager.showCollectorUpdateNotification();
+      } else {
+        rethrow;
       }
     }
   }

--- a/bindays_app/lib/data/notifications_manager.dart
+++ b/bindays_app/lib/data/notifications_manager.dart
@@ -40,7 +40,7 @@ class NotificationsManager {
     iOS: DarwinNotificationDetails(),
   );
 
-  static Future<void> init() async {
+  static Future<void> init({bool requestPermissions = true}) async {
     // Android initialisation settings
     const AndroidInitializationSettings androidInitializationSettings =
         AndroidInitializationSettings('notification_icon');
@@ -62,7 +62,9 @@ class NotificationsManager {
     // Initialize the plugin
     await flutterLocalNotificationsPlugin.initialize(initializationSettings);
 
-    _requestPermissions();
+    if (requestPermissions) {
+      _requestPermissions();
+    }
   }
 
   /// Request device permissions

--- a/bindays_app/lib/data/notifications_manager.dart
+++ b/bindays_app/lib/data/notifications_manager.dart
@@ -19,6 +19,10 @@ class NotificationsManager {
   /// "no more notifications" reminder.
   static const int _maxBinCollectionNotifications = 63;
 
+  /// Fixed ID for the collector-update notification so repeated background
+  /// fetches replace the existing notification rather than stacking new ones.
+  static const int _collectorUpdateNotificationId = 0;
+
   /// Token for the currently active scheduling operation. Cancelled when
   /// a new scheduling call supersedes it.
   static CancellationToken? _activeCancellationToken;
@@ -219,6 +223,20 @@ class NotificationsManager {
         androidScheduleMode: AndroidScheduleMode.exactAllowWhileIdle,
       );
     }
+  }
+
+  /// Shows an immediate notification informing the user that their address
+  /// must be re-selected because the council's data format has changed.
+  ///
+  /// Uses a fixed notification ID so repeated background fetches replace the
+  /// existing notification rather than creating duplicates.
+  static Future<void> showCollectorUpdateNotification() async {
+    await flutterLocalNotificationsPlugin.show(
+      _collectorUpdateNotificationId,
+      'Council Website Changed',
+      'Your council has changed their website and your saved address is no longer compatible. Open BinDays to re-select your address and continue receiving bin collections.',
+      notificationDetails,
+    );
   }
 
   /// Schedules all bin collection notifications from global state.

--- a/bindays_app/lib/misc/collector_version_error.dart
+++ b/bindays_app/lib/misc/collector_version_error.dart
@@ -1,0 +1,10 @@
+/// Returns true if [error] is an HTTP 410 response, indicating the stored
+/// collector version is out of date and the user must re-select their address.
+bool isCollectorVersionOutdated(Object error) {
+  try {
+    final dynamic dynamicError = error;
+    return dynamicError.response?.statusCode == 410;
+  } catch (_) {
+    return false;
+  }
+}

--- a/bindays_app/lib/misc/navigators.dart
+++ b/bindays_app/lib/misc/navigators.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 // Internal Imports
 import 'package:bindays_app/pages/bin_days_page.dart';
+import 'package:bindays_app/pages/collector_outdated_page.dart';
 import 'package:bindays_app/pages/setup/addresses/addresses_not_found_page.dart';
 import 'package:bindays_app/pages/setup/addresses/finding_addresses_page.dart';
 import 'package:bindays_app/pages/setup/addresses/select_address_page.dart';
@@ -104,6 +105,18 @@ void navigateToAddressNotFoundPage(
   _navigateToPage(
     context,
     const AddressesNotFoundPage(),
+    pushReplacement: pushReplacement,
+  );
+}
+
+/// Navigates to the CollectorOutdatedPage.
+void navigateToCollectorOutdatedPage(
+  BuildContext context, {
+  bool pushReplacement = false,
+}) {
+  _navigateToPage(
+    context,
+    const CollectorOutdatedPage(),
     pushReplacement: pushReplacement,
   );
 }

--- a/bindays_app/lib/pages/bin_days_page.dart
+++ b/bindays_app/lib/pages/bin_days_page.dart
@@ -81,6 +81,8 @@ class _BinDaysPageState extends State<BinDaysPage> {
     } catch (e) {
       if (isCollectorVersionOutdated(e) && mounted) {
         navigateToCollectorOutdatedPage(context);
+      } else {
+        rethrow;
       }
     } finally {
       setState(() {

--- a/bindays_app/lib/pages/bin_days_page.dart
+++ b/bindays_app/lib/pages/bin_days_page.dart
@@ -5,6 +5,7 @@ import 'package:in_app_review/in_app_review.dart';
 // Internal Imports
 import 'package:bindays_app/client/bindays_client.dart';
 import 'package:bindays_app/data/shared_preferences_manager.dart';
+import 'package:bindays_app/misc/collector_version_error.dart';
 import 'package:bindays_app/notifiers/global_notifiers.dart';
 import 'package:bindays_app/misc/navigators.dart';
 import 'package:bindays_app/pages/safe_base_page.dart';
@@ -76,12 +77,16 @@ class _BinDaysPageState extends State<BinDaysPage> {
         await SharedPreferencesManager.setRequestReviewAfter(twoWeeksFromNow);
       }
       _checkAndRequestReview();
+      globalStateNotifier.setLastRefresh(DateTime.now());
+    } catch (e) {
+      if (isCollectorVersionOutdated(e) && mounted) {
+        navigateToCollectorOutdatedPage(context);
+      }
     } finally {
       setState(() {
         _isRefreshing = false;
       });
     }
-    globalStateNotifier.setLastRefresh(DateTime.now());
   }
 
   Future<void> _checkAndRequestReview() async {

--- a/bindays_app/lib/pages/collector_outdated_page.dart
+++ b/bindays_app/lib/pages/collector_outdated_page.dart
@@ -1,0 +1,32 @@
+// External Imports
+import 'package:flutter/material.dart';
+
+// Internal Imports
+import 'package:bindays_app/data/setup_state.dart';
+import 'package:bindays_app/misc/navigators.dart';
+import 'package:bindays_app/notifiers/global_notifiers.dart';
+import 'package:bindays_app/pages/setup/generics/not_found_page.dart';
+import 'package:bindays_app/widgets/primary_button.dart';
+
+class CollectorOutdatedPage extends StatelessWidget {
+  const CollectorOutdatedPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return NotFoundPage(
+      headline: 'Council Website Changed',
+      message:
+          'Your council has changed their website and your saved address is '
+          'no longer compatible.\n\n'
+          'Please re-select your address to continue receiving bin collections.',
+      button: PrimaryButton(
+        text: 'Re-select Address',
+        onPressed: () {
+          setupState.collector = globalStateNotifier.collector;
+          setupState.postcode = globalStateNotifier.address?.postcode;
+          navigateToFindingAddressesPage(context);
+        },
+      ),
+    );
+  }
+}

--- a/bindays_app/pubspec.yaml
+++ b/bindays_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.4.2+1
+version: 2.5.0+1
 
 environment:
   sdk: ^3.7.0

--- a/bindays_app/release_notes.json
+++ b/bindays_app/release_notes.json
@@ -1,10 +1,10 @@
 [
     {
         "language": "en-GB",
-        "text": "Fixed an issue where the 'no more notifications' reminder was not always scheduled correctly."
+        "text": "Added a notification and in-app prompt when your council updates their website, letting you know your address needs to be re-selected."
     },
     {
         "language": "en-US",
-        "text": "Fixed an issue where the 'no more notifications' reminder was not always scheduled correctly."
+        "text": "Added a notification and in-app prompt when your council updates their website, letting you know your address needs to be re-selected."
     }
 ]


### PR DESCRIPTION
## Summary

- When the API returns 410 (collector version out of date), navigates the user to a new `CollectorOutdatedPage` explaining their council's website has changed and prompting them to re-select their address
- In the background refresh task, fires an immediate notification instead of silently failing
- Skips retrying on 410 errors in `ClientWithRetry` since the error is permanent until the user acts
- Extracts shared `isCollectorVersionOutdated()` helper to `lib/misc/collector_version_error.dart` to avoid duplication across three callers

## Test plan

- [ ] Trigger a 410 response from the API and confirm `CollectorOutdatedPage` is shown with the correct message and green "Re-select Address" button
- [ ] Confirm "Re-select Address" navigates through the address selection flow and lands back on the bin days page
- [ ] Confirm the Android back button dismisses the page without crashing
- [ ] Trigger the background refresh with a 410 response and confirm the "Council Website Changed" notification fires
- [ ] Confirm no notification is shown on a successful background refresh
- [ ] Run `flutter analyze` — no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)