### PR TITLE
Prefill support email body with known app context

### DIFF
--- a/bindays_app/lib/pages/settings_page.dart
+++ b/bindays_app/lib/pages/settings_page.dart
@@ -44,7 +44,7 @@ class _SettingsPageState extends State<SettingsPage> {
         globalStateNotifier.address?.toFormattedString() ?? "Not set";
     final body =
         "[Please describe your issue or feedback here]\n\n---\n\nCollector: $collector\nAddress: $address";
-    return "mailto:contact@bindays.app?subject=$subject&body=${Uri.encodeComponent(body)}";
+    return "mailto:contact@bindays.app?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}";
   }
 
   @override

--- a/bindays_app/lib/pages/settings_page.dart
+++ b/bindays_app/lib/pages/settings_page.dart
@@ -33,13 +33,18 @@ class _SettingsPageState extends State<SettingsPage> {
   }
 
   String _getEmailUrl() {
-    var emailUrl = "mailto:contact@bindays.app?subject=BinDays Feedback";
+    var subject = "BinDays Feedback";
     if (Platform.isIOS) {
-      emailUrl += " (iOS)";
+      subject += " (iOS)";
     } else if (Platform.isAndroid) {
-      emailUrl += " (Android)";
+      subject += " (Android)";
     }
-    return emailUrl;
+    final collector = globalStateNotifier.collector?.name ?? "Not set";
+    final address =
+        globalStateNotifier.address?.toFormattedString() ?? "Not set";
+    final body =
+        "[Please describe your issue or feedback here]\n\n---\n\nCollector: $collector\nAddress: $address";
+    return "mailto:contact@bindays.app?subject=$subject&body=${Uri.encodeComponent(body)}";
   }
 
   @override

--- a/bindays_app/lib/pages/setup/collectors/request_council_page.dart
+++ b/bindays_app/lib/pages/setup/collectors/request_council_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
 // Internal Imports
+import 'package:bindays_app/data/setup_state.dart';
 import 'package:bindays_app/pages/safe_base_page.dart';
 import 'package:bindays_app/widgets/primary_button.dart';
 import 'package:bindays_app/widgets/secondary_button.dart';
@@ -13,13 +14,16 @@ class RequestCouncilPage extends StatelessWidget {
   const RequestCouncilPage({super.key});
 
   String _getEmailUrl() {
-    var emailUrl = "mailto:contact@bindays.app?subject=BinDays Feedback";
+    var subject = "BinDays Feedback";
     if (Platform.isIOS) {
-      emailUrl += " (iOS)";
+      subject += " (iOS)";
     } else if (Platform.isAndroid) {
-      emailUrl += " (Android)";
+      subject += " (Android)";
     }
-    return emailUrl;
+    final postcode = setupState.postcode ?? "Not set";
+    final body =
+        "[Please describe your issue or feedback here]\n\n---\n\nPostcode: $postcode";
+    return "mailto:contact@bindays.app?subject=$subject&body=${Uri.encodeComponent(body)}";
   }
 
   @override

--- a/bindays_app/lib/pages/setup/collectors/request_council_page.dart
+++ b/bindays_app/lib/pages/setup/collectors/request_council_page.dart
@@ -23,7 +23,7 @@ class RequestCouncilPage extends StatelessWidget {
     final postcode = setupState.postcode ?? "Not set";
     final body =
         "[Please describe your issue or feedback here]\n\n---\n\nPostcode: $postcode";
-    return "mailto:contact@bindays.app?subject=$subject&body=${Uri.encodeComponent(body)}";
+    return "mailto:contact@bindays.app?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}";
   }
 
   @override

--- a/bindays_app/lib/pages/setup/generics/not_found_page.dart
+++ b/bindays_app/lib/pages/setup/generics/not_found_page.dart
@@ -31,7 +31,7 @@ class NotFoundPage extends StatelessWidget {
     final postcode = setupState.postcode ?? "Not set";
     final body =
         "[Please describe your issue or feedback here]\n\n---\n\nPostcode: $postcode";
-    return "mailto:contact@bindays.app?subject=$subject&body=${Uri.encodeComponent(body)}";
+    return "mailto:contact@bindays.app?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}";
   }
 
   @override

--- a/bindays_app/lib/pages/setup/generics/not_found_page.dart
+++ b/bindays_app/lib/pages/setup/generics/not_found_page.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 
 // Internal Imports
+import 'package:bindays_app/data/setup_state.dart';
 import 'package:bindays_app/pages/safe_base_page.dart';
 import 'package:bindays_app/widgets/url_link.dart';
 
@@ -21,13 +22,16 @@ class NotFoundPage extends StatelessWidget {
   });
 
   String _getEmailUrl() {
-    var emailUrl = "mailto:contact@bindays.app?subject=BinDays Feedback";
+    var subject = "BinDays Feedback";
     if (Platform.isIOS) {
-      emailUrl += " (iOS)";
+      subject += " (iOS)";
     } else if (Platform.isAndroid) {
-      emailUrl += " (Android)";
+      subject += " (Android)";
     }
-    return emailUrl;
+    final postcode = setupState.postcode ?? "Not set";
+    final body =
+        "[Please describe your issue or feedback here]\n\n---\n\nPostcode: $postcode";
+    return "mailto:contact@bindays.app?subject=$subject&body=${Uri.encodeComponent(body)}";
   }
 
   @override


### PR DESCRIPTION
## Summary
- Prefills the support email body with collector name and address (settings page) or postcode (setup flow pages) so support staff have diagnostic info upfront
- Falls back to "Not set" for any null values, preventing crashes
- Updates all three `_getEmailUrl()` call sites: `settings_page.dart`, `request_council_page.dart`, and `not_found_page.dart`

Closes #17

## Test plan
- [x] Settings -> Send Feedback -> email opens with collector name and address in body
- [x] Setup flow with unknown postcode -> not found page -> email link -> postcode appears in body
- [x] Not found page -> Request Council page -> email link -> postcode appears in body
- [ ] Verify "Not set" fallback if values are unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
