### PR TITLE
feat: Add troubleshooting flow (v2.6.0)

### DIFF
--- a/bindays_app/lib/misc/issue_type.dart
+++ b/bindays_app/lib/misc/issue_type.dart
@@ -1,0 +1,19 @@
+enum IssueType {
+  addressNotFound,
+  noBinCollectionsFound,
+  incorrectOrMissingBins,
+  somethingElse;
+
+  String get displayName {
+    switch (this) {
+      case IssueType.addressNotFound:
+        return 'Address not found';
+      case IssueType.noBinCollectionsFound:
+        return 'No bin collections showing';
+      case IssueType.incorrectOrMissingBins:
+        return 'Wrong or missing bin dates';
+      case IssueType.somethingElse:
+        return 'Something else';
+    }
+  }
+}

--- a/bindays_app/lib/misc/navigators.dart
+++ b/bindays_app/lib/misc/navigators.dart
@@ -2,8 +2,11 @@
 import 'package:flutter/material.dart';
 
 // Internal Imports
+import 'package:bindays_app/misc/issue_type.dart';
 import 'package:bindays_app/pages/bin_days_page.dart';
 import 'package:bindays_app/pages/collector_outdated_page.dart';
+import 'package:bindays_app/pages/report_issue_page.dart';
+import 'package:bindays_app/pages/troubleshooting_page.dart';
 import 'package:bindays_app/pages/setup/addresses/addresses_not_found_page.dart';
 import 'package:bindays_app/pages/setup/addresses/finding_addresses_page.dart';
 import 'package:bindays_app/pages/setup/addresses/select_address_page.dart';
@@ -17,6 +20,7 @@ import 'package:bindays_app/pages/setup/enter_postcode_page.dart';
 import 'package:bindays_app/pages/setup/how_it_works_page.dart';
 import 'package:bindays_app/pages/settings_page.dart';
 import 'package:bindays_app/pages/notifications_page.dart';
+import 'package:bindays_app/pages/verify_council_page.dart';
 
 /// Navigates to the HowItWorksPage.
 void navigateToHowItWorksPage(BuildContext context) {
@@ -134,6 +138,34 @@ void navigateToSettingsPage(BuildContext context) {
 /// Navigate to NotificationsPage.
 void navigateToNotificationsPage(BuildContext context) {
   _navigateToPage(context, const NotificationsPage());
+}
+
+/// Navigate to TroubleshootingPage.
+void navigateToTroubleshootingPage(BuildContext context) {
+  _navigateToPage(context, const TroubleshootingPage());
+}
+
+/// Navigate to VerifyCouncilPage.
+void navigateToVerifyCouncilPage(
+  BuildContext context, {
+  required IssueType issueType,
+}) {
+  _navigateToPage(context, VerifyCouncilPage(issueType: issueType));
+}
+
+/// Navigate to ReportIssuePage.
+void navigateToReportIssuePage(
+  BuildContext context, {
+  required IssueType issueType,
+  required bool? councilWebsiteWorking,
+}) {
+  _navigateToPage(
+    context,
+    ReportIssuePage(
+      issueType: issueType,
+      councilWebsiteWorking: councilWebsiteWorking,
+    ),
+  );
 }
 
 /// Navigates to a specified page.

--- a/bindays_app/lib/pages/bin_days_page.dart
+++ b/bindays_app/lib/pages/bin_days_page.dart
@@ -116,6 +116,10 @@ class _BinDaysPageState extends State<BinDaysPage> {
     return Scaffold(
       appBar: AppBar(
         automaticallyImplyLeading: false,
+        leading: IconButton(
+          icon: const Icon(Icons.help_outline),
+          onPressed: () => navigateToTroubleshootingPage(context),
+        ),
         actions: [
           IconButton(
             icon: const Icon(Icons.settings),

--- a/bindays_app/lib/pages/report_issue_page.dart
+++ b/bindays_app/lib/pages/report_issue_page.dart
@@ -1,0 +1,128 @@
+// External Imports
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher_string.dart';
+
+// Internal Imports
+import 'package:bindays_app/extensions/address_extension.dart';
+import 'package:bindays_app/misc/issue_type.dart';
+import 'package:bindays_app/notifiers/global_notifiers.dart';
+import 'package:bindays_app/widgets/primary_button.dart';
+import 'package:bindays_app/widgets/secondary_button.dart';
+
+class ReportIssuePage extends StatelessWidget {
+  final IssueType issueType;
+  final bool? councilWebsiteWorking;
+
+  const ReportIssuePage({
+    super.key,
+    required this.issueType,
+    required this.councilWebsiteWorking,
+  });
+
+  String _getEmailUrl() {
+    var subject = "BinDays Issue Report";
+    if (Platform.isIOS) {
+      subject += " (iOS)";
+    } else if (Platform.isAndroid) {
+      subject += " (Android)";
+    }
+    final issue = issueType.displayName;
+    final councilStatus = switch (councilWebsiteWorking) {
+      true => 'Working',
+      false => 'Has an issue',
+      null => 'N/A',
+    };
+    final collector = globalStateNotifier.collector?.name ?? "Not set";
+    final address =
+        globalStateNotifier.address?.toFormattedString() ?? "Not set";
+    final body =
+        "[Please describe your issue here]\n\n---\n\nIssue: $issue\nCouncil website: $councilStatus\nCollector: $collector\nAddress: $address";
+    return "mailto:contact@bindays.app?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}";
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Report an Issue")),
+      body: SafeArea(
+        minimum: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      "Thanks for confirming. Please include as much of the following as you can to help us look into it quickly.",
+                      style: TextStyle(
+                        fontSize:
+                            Theme.of(context).textTheme.bodyLarge!.fontSize,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+                    ...[
+                      "What the problem is and when you first noticed it.",
+                      "What BinDays is currently showing (dates, bin types, colours).",
+                      "What you expected to see, or what your council's website shows.",
+                      "Whether the issue affects all collections or just specific ones.",
+                      "Your postcode and council name, if not already included.",
+                    ].map(
+                      (item) => Padding(
+                        padding: const EdgeInsets.only(bottom: 8),
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              "•  ",
+                              style: TextStyle(
+                                fontSize: Theme.of(
+                                  context,
+                                ).textTheme.bodyLarge!.fontSize,
+                                color: Theme.of(
+                                  context,
+                                ).colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            Expanded(
+                              child: Text(
+                                item,
+                                style: TextStyle(
+                                  fontSize: Theme.of(
+                                    context,
+                                  ).textTheme.bodyLarge!.fontSize,
+                                  color: Theme.of(
+                                    context,
+                                  ).colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            PrimaryButton(
+              text: "Send an Email",
+              onPressed: () => launchUrlString(_getEmailUrl()),
+            ),
+            const SizedBox(height: 10),
+            SecondaryButton(
+              text: "Open a GitHub Issue",
+              onPressed: () => launchUrlString(
+                "https://github.com/BadgerHobbs/BinDays-App/issues/new",
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bindays_app/lib/pages/report_issue_page.dart
+++ b/bindays_app/lib/pages/report_issue_page.dart
@@ -1,5 +1,4 @@
 // External Imports
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher_string.dart';
 
@@ -7,6 +6,7 @@ import 'package:url_launcher/url_launcher_string.dart';
 import 'package:bindays_app/extensions/address_extension.dart';
 import 'package:bindays_app/misc/issue_type.dart';
 import 'package:bindays_app/notifiers/global_notifiers.dart';
+import 'package:bindays_app/pages/safe_base_page.dart';
 import 'package:bindays_app/widgets/primary_button.dart';
 import 'package:bindays_app/widgets/secondary_button.dart';
 
@@ -20,11 +20,12 @@ class ReportIssuePage extends StatelessWidget {
     required this.councilWebsiteWorking,
   });
 
-  String _getEmailUrl() {
+  String _getEmailUrl(BuildContext context) {
     var subject = "BinDays Issue Report";
-    if (Platform.isIOS) {
+    final platform = Theme.of(context).platform;
+    if (platform == TargetPlatform.iOS) {
       subject += " (iOS)";
-    } else if (Platform.isAndroid) {
+    } else if (platform == TargetPlatform.android) {
       subject += " (Android)";
     }
     final issue = issueType.displayName;
@@ -41,12 +42,28 @@ class ReportIssuePage extends StatelessWidget {
     return "mailto:contact@bindays.app?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}";
   }
 
+  Future<void> _launchUrl(BuildContext context, String urlString) async {
+    try {
+      final launched = await launchUrlString(urlString);
+      if (!launched && context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not open link')),
+        );
+      }
+    } catch (e) {
+      if (context.mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not open link')),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(title: const Text("Report an Issue")),
-      body: SafeArea(
-        minimum: const EdgeInsets.all(16),
+      body: SafeBasePage(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -111,12 +128,13 @@ class ReportIssuePage extends StatelessWidget {
             const SizedBox(height: 16),
             PrimaryButton(
               text: "Send an Email",
-              onPressed: () => launchUrlString(_getEmailUrl()),
+              onPressed: () => _launchUrl(context, _getEmailUrl(context)),
             ),
             const SizedBox(height: 10),
             SecondaryButton(
               text: "Open a GitHub Issue",
-              onPressed: () => launchUrlString(
+              onPressed: () => _launchUrl(
+                context,
                 "https://github.com/BadgerHobbs/BinDays-App/issues/new",
               ),
             ),

--- a/bindays_app/lib/pages/settings_page.dart
+++ b/bindays_app/lib/pages/settings_page.dart
@@ -50,10 +50,7 @@ class _SettingsPageState extends State<SettingsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text("Settings"),
-        automaticallyImplyLeading: false,
-      ),
+      appBar: AppBar(title: const Text("Settings")),
       body: SafeBasePage(
         child: ListView(
           children: [
@@ -118,7 +115,20 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
             const SizedBox(height: 20),
             Text(
-              'User Feedback',
+              'Help & Support',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Troubleshoot an Issue'),
+              subtitle: const Text(
+                'Find answers to common problems or get in touch.',
+              ),
+              onTap: () => navigateToTroubleshootingPage(context),
+            ),
+            const SizedBox(height: 20),
+            Text(
+              'Feedback',
               style: Theme.of(context).textTheme.titleMedium,
             ),
             ListTile(

--- a/bindays_app/lib/pages/setup/generics/not_found_page.dart
+++ b/bindays_app/lib/pages/setup/generics/not_found_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 
 // Internal Imports
 import 'package:bindays_app/misc/navigators.dart';
+import 'package:bindays_app/pages/safe_base_page.dart';
 
 class NotFoundPage extends StatelessWidget {
   final String headline;
@@ -22,8 +23,7 @@ class NotFoundPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(),
-      body: SafeArea(
-        minimum: const EdgeInsets.all(16),
+      body: SafeBasePage(
         child: Column(
           children: [
             const Spacer(flex: 1),

--- a/bindays_app/lib/pages/setup/generics/not_found_page.dart
+++ b/bindays_app/lib/pages/setup/generics/not_found_page.dart
@@ -1,11 +1,8 @@
 // External Imports
-import 'dart:io';
 import 'package:flutter/material.dart';
 
 // Internal Imports
-import 'package:bindays_app/data/setup_state.dart';
-import 'package:bindays_app/pages/safe_base_page.dart';
-import 'package:bindays_app/widgets/url_link.dart';
+import 'package:bindays_app/misc/navigators.dart';
 
 class NotFoundPage extends StatelessWidget {
   final String headline;
@@ -21,67 +18,75 @@ class NotFoundPage extends StatelessWidget {
     this.extraButton,
   });
 
-  String _getEmailUrl() {
-    var subject = "BinDays Feedback";
-    if (Platform.isIOS) {
-      subject += " (iOS)";
-    } else if (Platform.isAndroid) {
-      subject += " (Android)";
-    }
-    final postcode = setupState.postcode ?? "Not set";
-    final body =
-        "[Please describe your issue or feedback here]\n\n---\n\nPostcode: $postcode";
-    return "mailto:contact@bindays.app?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}";
-  }
-
   @override
   Widget build(BuildContext context) {
-    return SafeBasePage(
-      child: Column(
-        children: [
-          const Spacer(flex: 1),
-          Flexible(
-            flex: 2,
-            child: Image.asset('assets/illustrations/Navigation_Two_Color.png'),
-          ),
-          const SizedBox(height: 25),
-          Text(
-            headline,
-            style: TextStyle(
-              fontSize: Theme.of(context).textTheme.headlineMedium!.fontSize,
-              fontWeight: FontWeight.bold,
-            ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 10),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 20),
-            child: Text(
-              message,
-              textAlign: TextAlign.left,
-              style: TextStyle(
-                fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
-                color: Theme.of(context).colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ),
-
-          const Spacer(flex: 1),
-          Column(
-            children: [
-              UrlLink(
-                text: "Send feedback to contact@bindays.app",
-                url: _getEmailUrl(),
-              ),
-              const SizedBox(height: 10),
-              button,
-              if (extraButton != null) ...[
-                const SizedBox(height: 10),
-                extraButton!,
-              ],
-            ],
+    return Scaffold(
+      appBar: AppBar(
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline),
+            onPressed: () => navigateToTroubleshootingPage(context),
           ),
         ],
+      ),
+      body: SafeArea(
+        minimum: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            const Spacer(flex: 1),
+            Flexible(
+              flex: 2,
+              child: Image.asset(
+                'assets/illustrations/Navigation_Two_Color.png',
+              ),
+            ),
+            const SizedBox(height: 25),
+            Text(
+              headline,
+              style: TextStyle(
+                fontSize: Theme.of(context).textTheme.headlineMedium!.fontSize,
+                fontWeight: FontWeight.bold,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 10),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 20),
+              child: Text(
+                message,
+                textAlign: TextAlign.left,
+                style: TextStyle(
+                  fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
+                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ),
+            const Spacer(flex: 1),
+            Column(
+              children: [
+                GestureDetector(
+                  onTap: () => navigateToTroubleshootingPage(context),
+                  child: Text(
+                    "Having trouble? Visit our Troubleshooting page.",
+                    style: TextStyle(
+                      fontSize:
+                          Theme.of(context).textTheme.bodyMedium!.fontSize,
+                      decoration: TextDecoration.underline,
+                      color: Theme.of(context).colorScheme.onSurfaceVariant,
+                    ),
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+                const SizedBox(height: 10),
+                button,
+                if (extraButton != null) ...[
+                  const SizedBox(height: 10),
+                  extraButton!,
+                ],
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/bindays_app/lib/pages/setup/generics/not_found_page.dart
+++ b/bindays_app/lib/pages/setup/generics/not_found_page.dart
@@ -21,14 +21,7 @@ class NotFoundPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.help_outline),
-            onPressed: () => navigateToTroubleshootingPage(context),
-          ),
-        ],
-      ),
+      appBar: AppBar(),
       body: SafeArea(
         minimum: const EdgeInsets.all(16),
         child: Column(

--- a/bindays_app/lib/pages/troubleshooting_page.dart
+++ b/bindays_app/lib/pages/troubleshooting_page.dart
@@ -1,0 +1,71 @@
+// External Imports
+import 'package:flutter/material.dart';
+
+// Internal Imports
+import 'package:bindays_app/misc/issue_type.dart';
+import 'package:bindays_app/misc/navigators.dart';
+import 'package:bindays_app/pages/safe_base_page.dart';
+
+class TroubleshootingPage extends StatelessWidget {
+  const TroubleshootingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text("Troubleshooting")),
+      body: SafeBasePage(
+        child: ListView(
+          children: [
+            Text(
+              "What's the problem?",
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text("Can't find my address"),
+              subtitle: const Text(
+                'No addresses appeared when searching your postcode.',
+              ),
+              onTap: () => navigateToVerifyCouncilPage(
+                context,
+                issueType: IssueType.addressNotFound,
+              ),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('No bin collections showing'),
+              subtitle: const Text(
+                'Address found, but no upcoming collections are listed.',
+              ),
+              onTap: () => navigateToVerifyCouncilPage(
+                context,
+                issueType: IssueType.noBinCollectionsFound,
+              ),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Wrong or missing bin dates'),
+              subtitle: const Text(
+                "Dates, bin types, or colours don't match what you'd expect.",
+              ),
+              onTap: () => navigateToVerifyCouncilPage(
+                context,
+                issueType: IssueType.incorrectOrMissingBins,
+              ),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
+              title: const Text('Something else'),
+              subtitle: const Text("My problem isn't listed here."),
+              onTap: () => navigateToReportIssuePage(
+                context,
+                issueType: IssueType.somethingElse,
+                councilWebsiteWorking: null,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bindays_app/lib/pages/verify_council_page.dart
+++ b/bindays_app/lib/pages/verify_council_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:bindays_app/misc/issue_type.dart';
 import 'package:bindays_app/misc/navigators.dart';
 import 'package:bindays_app/notifiers/global_notifiers.dart';
+import 'package:bindays_app/pages/safe_base_page.dart';
 import 'package:bindays_app/widgets/primary_button.dart';
 import 'package:bindays_app/widgets/secondary_button.dart';
 import 'package:bindays_app/widgets/url_link.dart';
@@ -20,8 +21,7 @@ class VerifyCouncilPage extends StatelessWidget {
 
     return Scaffold(
       appBar: AppBar(title: const Text("Before You Report")),
-      body: SafeArea(
-        minimum: const EdgeInsets.all(16),
+      body: SafeBasePage(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [

--- a/bindays_app/lib/pages/verify_council_page.dart
+++ b/bindays_app/lib/pages/verify_council_page.dart
@@ -1,0 +1,96 @@
+// External Imports
+import 'package:flutter/material.dart';
+// Internal Imports
+import 'package:bindays_app/misc/issue_type.dart';
+import 'package:bindays_app/misc/navigators.dart';
+import 'package:bindays_app/notifiers/global_notifiers.dart';
+import 'package:bindays_app/widgets/primary_button.dart';
+import 'package:bindays_app/widgets/secondary_button.dart';
+import 'package:bindays_app/widgets/url_link.dart';
+
+
+class VerifyCouncilPage extends StatelessWidget {
+  final IssueType issueType;
+
+  const VerifyCouncilPage({super.key, required this.issueType});
+
+  @override
+  Widget build(BuildContext context) {
+    final websiteUrl = globalStateNotifier.collector?.websiteUrl;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("Before You Report")),
+      body: SafeArea(
+        minimum: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Expanded(
+              child: SingleChildScrollView(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      "BinDays pulls its data directly from your council's website. If the council site is down or out of date, that'll affect BinDays too.",
+                      style: TextStyle(
+                        fontSize:
+                            Theme.of(context).textTheme.bodyLarge!.fontSize,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      "Around bank holidays, councils often change their collection schedules without updating their website straight away.",
+                      style: TextStyle(
+                        fontSize:
+                            Theme.of(context).textTheme.bodyLarge!.fontSize,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    const SizedBox(height: 12),
+                    Text(
+                      "Please check that your council's website is showing the correct information before reporting an issue with BinDays.",
+                      style: TextStyle(
+                        fontSize:
+                            Theme.of(context).textTheme.bodyLarge!.fontSize,
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                    if (websiteUrl != null) ...[
+                      const SizedBox(height: 16),
+                      Center(
+                        child: UrlLink(
+                          text: "Visit ${globalStateNotifier.collector?.name ?? 'council'} website",
+                          url: websiteUrl.toString(),
+                          fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ),
+            const SizedBox(height: 16),
+            PrimaryButton(
+              text: "Yes, it's working fine",
+              onPressed: () => navigateToReportIssuePage(
+                context,
+                issueType: issueType,
+                councilWebsiteWorking: true,
+              ),
+            ),
+            const SizedBox(height: 10),
+            SecondaryButton(
+              text: "No, there's a problem",
+              onPressed: () => navigateToReportIssuePage(
+                context,
+                issueType: issueType,
+                councilWebsiteWorking: false,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/bindays_app/lib/widgets/url_link.dart
+++ b/bindays_app/lib/widgets/url_link.dart
@@ -5,8 +5,9 @@ import 'package:url_launcher/url_launcher_string.dart';
 class UrlLink extends StatelessWidget {
   final String text;
   final String url;
+  final double? fontSize;
 
-  const UrlLink({super.key, required this.text, required this.url});
+  const UrlLink({super.key, required this.text, required this.url, this.fontSize});
 
   @override
   Widget build(BuildContext context) {
@@ -15,7 +16,7 @@ class UrlLink extends StatelessWidget {
       child: Text(
         text,
         style: TextStyle(
-          fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+          fontSize: fontSize ?? Theme.of(context).textTheme.bodyMedium!.fontSize,
           decoration: TextDecoration.underline,
           color: Theme.of(context).colorScheme.onSurfaceVariant,
         ),

--- a/bindays_app/pubspec.yaml
+++ b/bindays_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.5.1+1
+version: 2.6.0+1
 
 environment:
   sdk: ^3.7.0

--- a/bindays_app/release_notes.json
+++ b/bindays_app/release_notes.json
@@ -1,10 +1,10 @@
 [
     {
         "language": "en-GB",
-        "text": "Fixed an issue where bin collection days could not be retrieved for some East Ayrshire Council addresses."
+        "text": "Added a Troubleshooting flow to help diagnose common issues, accessible from the main screen, settings, and error pages."
     },
     {
         "language": "en-US",
-        "text": "Fixed an issue where bin collection days could not be retrieved for some East Ayrshire Council addresses."
+        "text": "Added a Troubleshooting flow to help diagnose common issues, accessible from the main screen, settings, and error pages."
     }
 ]


### PR DESCRIPTION
## Summary

- Adds a guided troubleshooting flow with pages for issue selection, council website verification, and issue reporting
- Help icon (`?`) added to main bin collections page (leading) and accessible via Settings > Help & Support > Troubleshoot an Issue
- Error pages include a visible "Having trouble? Visit our Troubleshooting page." link in the page body
- Users are directed to check their council's website (with a named link) before reporting, including a note about bank holidays as a common cause of incorrect dates
- Report an Issue page prefills email with issue type, council website status, collector name, and address
- Reporting available via email or GitHub issue

## Test plan

- [x] Tap `?` icon on main screen — Troubleshooting page opens
- [x] Navigate to Settings > Help & Support > Troubleshoot an Issue — same page opens
- [x] Trigger an error page (e.g. bad postcode) — "Having trouble?" link visible, tapping opens Troubleshooting page
- [x] Select each issue type — first three go to "Before You Report", "Something else" goes directly to "Report an Issue"
- [x] "Before You Report" shows council name in the link and both buttons navigate to "Report an Issue"
- [x] "Report an Issue" email button opens mail client with prefilled subject and body
- [x] "Report an Issue" GitHub button opens browser to new issue form

🤖 Generated with [Claude Code](https://claude.com/claude-code)