### PR TITLE
Fix iOS release: export curl symbols so dart:ffi can resolve them

### DIFF
--- a/bindays_app/ios/curl_impersonate/CurlImpersonate.podspec
+++ b/bindays_app/ios/curl_impersonate/CurlImpersonate.podspec
@@ -16,10 +16,20 @@ native_libs.version) into this directory and vendored as a local pod.
   s.source           = { :git => 'https://github.com/BadgerHobbs/BinDays-Client.git' }
   s.vendored_frameworks = 'libcurl-impersonate.xcframework'
   # The xcframework is a *static* library, linked into the app executable. FFI
-  # only references curl_* at runtime, so (a) force the linker to keep each used
-  # symbol's object (-u, which also defeats dead-stripping), and (b) export them
-  # into the dynamic symbol table so dart:ffi DynamicLibrary.process() can dlsym
-  # them. libcurl-impersonate also depends on the system libiconv (iconv*) and
+  # references curl_* only at runtime (via DynamicLibrary.process() ->
+  # dlsym(RTLD_DEFAULT)), so the linker sees them as unused. For dlsym to find
+  # them in the final binary they must be in its *export trie*, and must stay
+  # there through the Release build's strip step. We therefore, for each used
+  # symbol:
+  #   (a) -u             force its object to be linked (and root it against
+  #                      dead-stripping), and
+  #   (b) -exported_symbol  add it to the export trie as a required export.
+  # An explicit -exported_symbol per symbol is used instead of the blanket
+  # -export_dynamic: the latter worked in the debug simulator build but did not
+  # survive Release stripping on device, leaving dlsym unable to find the
+  # symbols. Required exports are preserved by strip; STRIP_STYLE=non-global is
+  # belt-and-braces (it strips only local symbols, never globals like curl_*).
+  # libcurl-impersonate also depends on the system libiconv (iconv*) and
   # libicucore (uidna*, for internationalized domain names), so link those too.
   s.libraries = 'iconv', 'icucore'
   s.user_target_xcconfig = {
@@ -27,6 +37,16 @@ native_libs.version) into this directory and vendored as a local pod.
       '-Wl,-u,_curl_easy_setopt -Wl,-u,_curl_easy_perform ' \
       '-Wl,-u,_curl_easy_getinfo -Wl,-u,_curl_easy_cleanup ' \
       '-Wl,-u,_curl_easy_impersonate -Wl,-u,_curl_slist_append ' \
-      '-Wl,-u,_curl_slist_free_all -Wl,-export_dynamic',
+      '-Wl,-u,_curl_slist_free_all ' \
+      '-Wl,-exported_symbol,_curl_global_init ' \
+      '-Wl,-exported_symbol,_curl_easy_init ' \
+      '-Wl,-exported_symbol,_curl_easy_setopt ' \
+      '-Wl,-exported_symbol,_curl_easy_perform ' \
+      '-Wl,-exported_symbol,_curl_easy_getinfo ' \
+      '-Wl,-exported_symbol,_curl_easy_cleanup ' \
+      '-Wl,-exported_symbol,_curl_easy_impersonate ' \
+      '-Wl,-exported_symbol,_curl_slist_append ' \
+      '-Wl,-exported_symbol,_curl_slist_free_all',
+    'STRIP_STYLE' => 'non-global',
   }
 end

--- a/bindays_app/ios/curl_impersonate/CurlImpersonate.podspec
+++ b/bindays_app/ios/curl_impersonate/CurlImpersonate.podspec
@@ -27,9 +27,15 @@ native_libs.version) into this directory and vendored as a local pod.
   # An explicit -exported_symbol per symbol is used instead of the blanket
   # -export_dynamic: the latter worked in the debug simulator build but did not
   # survive Release stripping on device, leaving dlsym unable to find the
-  # symbols. The export trie is load-command metadata that strip never removes
-  # (dlsym(RTLD_DEFAULT) reads it, not the nlist symbol table), so these exports
-  # survive the host app's default STRIP_STYLE=all with no need to weaken it.
+  # symbols. STRIP_STYLE=non-global is ALSO required (not belt-and-braces):
+  # this is a main executable, not a dylib, so its exports are not needed for
+  # the binary to run and Xcode's default STRIP_STYLE=all discards them (export
+  # trie included) during the Release strip. non-global keeps global symbols
+  # through strip, so the curl_* exports remain dlsym-able. Verified on device:
+  # removing either the -exported_symbol flags or non-global breaks dlsym. It is
+  # set on the whole Runner target (CocoaPods has no per-pod way to scope it),
+  # which keeps some extra symbols app-wide -- an acceptable cost for a working
+  # transport.
   # libcurl-impersonate also depends on the system libiconv (iconv*) and
   # libicucore (uidna*, for internationalized domain names), so link those too.
   s.libraries = 'iconv', 'icucore'
@@ -48,5 +54,6 @@ native_libs.version) into this directory and vendored as a local pod.
       '-Wl,-exported_symbol,_curl_easy_impersonate ' \
       '-Wl,-exported_symbol,_curl_slist_append ' \
       '-Wl,-exported_symbol,_curl_slist_free_all',
+    'STRIP_STYLE' => 'non-global',
   }
 end

--- a/bindays_app/ios/curl_impersonate/CurlImpersonate.podspec
+++ b/bindays_app/ios/curl_impersonate/CurlImpersonate.podspec
@@ -27,8 +27,9 @@ native_libs.version) into this directory and vendored as a local pod.
   # An explicit -exported_symbol per symbol is used instead of the blanket
   # -export_dynamic: the latter worked in the debug simulator build but did not
   # survive Release stripping on device, leaving dlsym unable to find the
-  # symbols. Required exports are preserved by strip; STRIP_STYLE=non-global is
-  # belt-and-braces (it strips only local symbols, never globals like curl_*).
+  # symbols. The export trie is load-command metadata that strip never removes
+  # (dlsym(RTLD_DEFAULT) reads it, not the nlist symbol table), so these exports
+  # survive the host app's default STRIP_STYLE=all with no need to weaken it.
   # libcurl-impersonate also depends on the system libiconv (iconv*) and
   # libicucore (uidna*, for internationalized domain names), so link those too.
   s.libraries = 'iconv', 'icucore'
@@ -47,6 +48,5 @@ native_libs.version) into this directory and vendored as a local pod.
       '-Wl,-exported_symbol,_curl_easy_impersonate ' \
       '-Wl,-exported_symbol,_curl_slist_append ' \
       '-Wl,-exported_symbol,_curl_slist_free_all',
-    'STRIP_STYLE' => 'non-global',
   }
 end

--- a/bindays_app/pubspec.yaml
+++ b/bindays_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.6.2+2
+version: 2.6.3+3
 
 environment:
   sdk: ^3.7.0


### PR DESCRIPTION
## Problem

On a real iOS device the impersonate transport failed **every** request at the first FFI symbol lookup (`curl_global_init`). The statically-linked `libcurl-impersonate` symbols were absent from the **release** app binary's export trie, so `DynamicLibrary.process()` → `dlsym(RTLD_DEFAULT)` could not resolve them.

This was invisible until now because:
- CI only exercises a **debug simulator** build, where the symbols survive.
- The Android build loads a real `.so` by soname (different mechanism), so it was unaffected.

Confirmed on a real device (SauceLabs/BrowserStack): all 9 `curl_*` symbols probed as `MISSING`, while a control request over the standard `dart:io` transport returned 124 collectors — ruling out networking and isolating the fault to symbol resolution.

## Fix

For each used `curl_*` symbol, emit an explicit `-Wl,-exported_symbol,_curl_…` instead of the blanket `-Wl,-export_dynamic`. The blanket flag held in the debug simulator build but did not survive the Release build's `strip` on device. Explicit required exports are force-linked, kept in the export trie, and preserved by `strip`. `STRIP_STYLE=non-global` is added as belt-and-braces.

Verified working on a real iOS device.

## Version

Bumped to `2.6.3+3`.