### PR TITLE
Release 2.6.4: issue-reporting improvements + 16 KB compatibility

### DIFF
--- a/bindays_app/lib/misc/navigators.dart
+++ b/bindays_app/lib/misc/navigators.dart
@@ -17,6 +17,7 @@ import 'package:bindays_app/pages/setup/collectors/finding_collector_page.dart';
 import 'package:bindays_app/pages/setup/collectors/request_council_page.dart';
 import 'package:bindays_app/pages/setup/collectors/select_collector_page.dart';
 import 'package:bindays_app/pages/setup/enter_postcode_page.dart';
+import 'package:bindays_app/pages/bins_not_collected_page.dart';
 import 'package:bindays_app/pages/setup/how_it_works_page.dart';
 import 'package:bindays_app/pages/settings_page.dart';
 import 'package:bindays_app/pages/notifications_page.dart';
@@ -143,6 +144,11 @@ void navigateToNotificationsPage(BuildContext context) {
 /// Navigate to TroubleshootingPage.
 void navigateToTroubleshootingPage(BuildContext context) {
   _navigateToPage(context, const TroubleshootingPage());
+}
+
+/// Navigate to BinsNotCollectedPage.
+void navigateToBinsNotCollectedPage(BuildContext context) {
+  _navigateToPage(context, const BinsNotCollectedPage());
 }
 
 /// Navigate to VerifyCouncilPage.

--- a/bindays_app/lib/pages/bins_not_collected_page.dart
+++ b/bindays_app/lib/pages/bins_not_collected_page.dart
@@ -1,0 +1,59 @@
+// External Imports
+import 'package:flutter/material.dart';
+
+// Internal Imports
+import 'package:bindays_app/notifiers/global_notifiers.dart';
+import 'package:bindays_app/pages/safe_base_page.dart';
+import 'package:bindays_app/widgets/url_link.dart';
+
+class BinsNotCollectedPage extends StatelessWidget {
+  const BinsNotCollectedPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final collector = globalStateNotifier.collector;
+    final websiteUrl = collector?.websiteUrl;
+
+    final bodyStyle = TextStyle(
+      fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
+      color: Theme.of(context).colorScheme.onSurfaceVariant,
+    );
+
+    return Scaffold(
+      appBar: AppBar(title: const Text("Bins Weren't Collected")),
+      body: SafeBasePage(
+        child: SingleChildScrollView(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                "Sorry to hear your bins weren't collected.",
+                style: bodyStyle,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                "BinDays only shows your council's published schedule. It isn't affiliated with your council and can't chase up a missed collection.",
+                style: bodyStyle,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                "Your council is responsible for collecting your bins, so please report any missed collection to them directly.",
+                style: bodyStyle,
+              ),
+              if (websiteUrl != null) ...[
+                const SizedBox(height: 16),
+                Center(
+                  child: UrlLink(
+                    text: "Visit ${collector?.name ?? 'council'} website",
+                    url: websiteUrl.toString(),
+                    fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/bindays_app/lib/pages/bins_not_collected_page.dart
+++ b/bindays_app/lib/pages/bins_not_collected_page.dart
@@ -15,7 +15,7 @@ class BinsNotCollectedPage extends StatelessWidget {
     final websiteUrl = collector?.websiteUrl;
 
     final bodyStyle = TextStyle(
-      fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
+      fontSize: Theme.of(context).textTheme.bodyLarge?.fontSize,
       color: Theme.of(context).colorScheme.onSurfaceVariant,
     );
 
@@ -46,7 +46,7 @@ class BinsNotCollectedPage extends StatelessWidget {
                   child: UrlLink(
                     text: "Visit ${collector?.name ?? 'council'} website",
                     url: websiteUrl.toString(),
-                    fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
+                    fontSize: Theme.of(context).textTheme.bodyLarge?.fontSize,
                   ),
                 ),
               ],

--- a/bindays_app/lib/pages/report_issue_page.dart
+++ b/bindays_app/lib/pages/report_issue_page.dart
@@ -9,8 +9,9 @@ import 'package:bindays_app/notifiers/global_notifiers.dart';
 import 'package:bindays_app/pages/safe_base_page.dart';
 import 'package:bindays_app/widgets/primary_button.dart';
 import 'package:bindays_app/widgets/secondary_button.dart';
+import 'package:bindays_app/widgets/text_input.dart';
 
-class ReportIssuePage extends StatelessWidget {
+class ReportIssuePage extends StatefulWidget {
   final IssueType issueType;
   final bool? councilWebsiteWorking;
 
@@ -20,7 +21,20 @@ class ReportIssuePage extends StatelessWidget {
     required this.councilWebsiteWorking,
   });
 
-  String _getEmailUrl(BuildContext context) {
+  @override
+  State<ReportIssuePage> createState() => _ReportIssuePageState();
+}
+
+class _ReportIssuePageState extends State<ReportIssuePage> {
+  final TextEditingController _descriptionController = TextEditingController();
+
+  @override
+  void dispose() {
+    _descriptionController.dispose();
+    super.dispose();
+  }
+
+  String _getEmailUrl(BuildContext context, String description) {
     var subject = "BinDays Issue Report";
     final platform = Theme.of(context).platform;
     if (platform == TargetPlatform.iOS) {
@@ -28,8 +42,8 @@ class ReportIssuePage extends StatelessWidget {
     } else if (platform == TargetPlatform.android) {
       subject += " (Android)";
     }
-    final issue = issueType.displayName;
-    final councilStatus = switch (councilWebsiteWorking) {
+    final issue = widget.issueType.displayName;
+    final councilStatus = switch (widget.councilWebsiteWorking) {
       true => 'Working',
       false => 'Has an issue',
       null => 'N/A',
@@ -38,7 +52,7 @@ class ReportIssuePage extends StatelessWidget {
     final address =
         globalStateNotifier.address?.toFormattedString() ?? "Not set";
     final body =
-        "[Please describe your issue here]\n\n---\n\nIssue: $issue\nCouncil website: $councilStatus\nCollector: $collector\nAddress: $address";
+        "${description.trim()}\n\n---\n\nIssue: $issue\nCouncil website: $councilStatus\nCollector: $collector\nAddress: $address";
     return "mailto:contact@bindays.app?subject=${Uri.encodeComponent(subject)}&body=${Uri.encodeComponent(body)}";
   }
 
@@ -73,7 +87,7 @@ class ReportIssuePage extends StatelessWidget {
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
                     Text(
-                      "Thanks for confirming. Please include as much of the following as you can to help us look into it quickly.",
+                      "Thanks for confirming. Please describe your issue below, including as much of the following as you can to help us look into it quickly.",
                       style: TextStyle(
                         fontSize:
                             Theme.of(context).textTheme.bodyLarge!.fontSize,
@@ -121,6 +135,17 @@ class ReportIssuePage extends StatelessWidget {
                         ),
                       ),
                     ),
+                    const SizedBox(height: 8),
+                    TextInput(
+                      controller: _descriptionController,
+                      hintText: "Describe your issue...",
+                      keyboardType: TextInputType.multiline,
+                      textCapitalization: TextCapitalization.sentences,
+                      textAlign: TextAlign.start,
+                      minLines: 4,
+                      maxLines: 8,
+                      onChanged: (_) => setState(() {}),
+                    ),
                   ],
                 ),
               ),
@@ -128,7 +153,11 @@ class ReportIssuePage extends StatelessWidget {
             const SizedBox(height: 16),
             PrimaryButton(
               text: "Send an Email",
-              onPressed: () => _launchUrl(context, _getEmailUrl(context)),
+              enabled: _descriptionController.text.trim().isNotEmpty,
+              onPressed: () => _launchUrl(
+                context,
+                _getEmailUrl(context, _descriptionController.text),
+              ),
             ),
             const SizedBox(height: 10),
             SecondaryButton(

--- a/bindays_app/lib/pages/troubleshooting_page.dart
+++ b/bindays_app/lib/pages/troubleshooting_page.dart
@@ -55,6 +55,14 @@ class TroubleshootingPage extends StatelessWidget {
             ),
             ListTile(
               contentPadding: EdgeInsets.zero,
+              title: const Text("Bins weren't collected"),
+              subtitle: const Text(
+                'Your council did not collect your bins.',
+              ),
+              onTap: () => navigateToBinsNotCollectedPage(context),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
               title: const Text('Something else'),
               subtitle: const Text("My problem isn't listed here."),
               onTap: () => navigateToReportIssuePage(

--- a/bindays_app/lib/pages/verify_council_page.dart
+++ b/bindays_app/lib/pages/verify_council_page.dart
@@ -72,7 +72,7 @@ class VerifyCouncilPage extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             PrimaryButton(
-              text: "Yes, it's working fine",
+              text: "Council website is correct",
               onPressed: () => navigateToReportIssuePage(
                 context,
                 issueType: issueType,
@@ -81,7 +81,7 @@ class VerifyCouncilPage extends StatelessWidget {
             ),
             const SizedBox(height: 10),
             SecondaryButton(
-              text: "No, there's a problem",
+              text: "Council website has a problem",
               onPressed: () => navigateToReportIssuePage(
                 context,
                 issueType: issueType,

--- a/bindays_app/lib/widgets/primary_button.dart
+++ b/bindays_app/lib/widgets/primary_button.dart
@@ -4,8 +4,14 @@ import 'package:flutter/material.dart';
 class PrimaryButton extends StatelessWidget {
   final String text;
   final VoidCallback onPressed;
+  final bool enabled;
 
-  const PrimaryButton({super.key, required this.text, required this.onPressed});
+  const PrimaryButton({
+    super.key,
+    required this.text,
+    required this.onPressed,
+    this.enabled = true,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -13,14 +19,17 @@ class PrimaryButton extends StatelessWidget {
       width: double.infinity,
       decoration: BoxDecoration(
         borderRadius: BorderRadius.circular(10),
-        color: const Color.fromRGBO(58, 119, 93, 1),
+        color: enabled
+            ? const Color.fromRGBO(58, 119, 93, 1)
+            : const Color.fromRGBO(58, 119, 93, 0.4),
       ),
       padding: const EdgeInsets.only(bottom: 7),
       child: ElevatedButton(
-        onPressed: onPressed,
+        onPressed: enabled ? onPressed : null,
         style: ElevatedButton.styleFrom(
           shadowColor: Colors.transparent,
           backgroundColor: const Color.fromRGBO(74, 149, 117, 1),
+          disabledBackgroundColor: const Color.fromRGBO(74, 149, 117, 0.4),
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(10),
           ),
@@ -28,7 +37,10 @@ class PrimaryButton extends StatelessWidget {
         ),
         child: Text(
           text,
-          style: const TextStyle(color: Colors.white, fontSize: 20),
+          style: TextStyle(
+            color: enabled ? Colors.white : Colors.white70,
+            fontSize: 20,
+          ),
           textAlign: TextAlign.center,
         ),
       ),

--- a/bindays_app/lib/widgets/text_input.dart
+++ b/bindays_app/lib/widgets/text_input.dart
@@ -5,25 +5,35 @@ class TextInput extends StatelessWidget {
   final TextEditingController controller;
   final String hintText;
   final ValueChanged<String>? onSubmitted;
+  final ValueChanged<String>? onChanged;
   final TextInputType keyboardType;
   final TextCapitalization textCapitalization;
+  final TextAlign textAlign;
+  final int? maxLines;
+  final int? minLines;
 
   const TextInput({
     super.key,
     required this.controller,
     required this.hintText,
     this.onSubmitted,
+    this.onChanged,
     // Defaults match the postcode field, but can be overridden if necessary
     this.keyboardType = TextInputType.text,
     this.textCapitalization = TextCapitalization.characters,
+    this.textAlign = TextAlign.center,
+    this.maxLines = 1,
+    this.minLines,
   });
 
   @override
   Widget build(BuildContext context) {
     const borderRadiusValue = 10.0;
-    const contentPadding = EdgeInsets.symmetric(vertical: 15.0);
+    const contentPadding = EdgeInsets.symmetric(
+      vertical: 15.0,
+      horizontal: 15.0,
+    );
     const textStyle = TextStyle(fontSize: 18);
-    const textAlign = TextAlign.center;
 
     final borderRadius = BorderRadius.circular(borderRadiusValue);
     final borderSide = BorderSide(
@@ -40,6 +50,8 @@ class TextInput extends StatelessWidget {
       keyboardType: keyboardType,
       textCapitalization: textCapitalization,
       textAlign: textAlign,
+      maxLines: maxLines,
+      minLines: minLines,
       style: textStyle,
       decoration: InputDecoration(
         hintText: hintText,
@@ -48,6 +60,7 @@ class TextInput extends StatelessWidget {
         enabledBorder: outlineInputBorder,
         focusedBorder: outlineInputBorder,
       ),
+      onChanged: onChanged,
       onSubmitted: onSubmitted,
     );
   }

--- a/bindays_app/lib/widgets/text_input.dart
+++ b/bindays_app/lib/widgets/text_input.dart
@@ -22,7 +22,8 @@ class TextInput extends StatelessWidget {
     this.keyboardType = TextInputType.text,
     this.textCapitalization = TextCapitalization.characters,
     this.textAlign = TextAlign.center,
-    this.maxLines = 1,
+    // Resolved in build(): defaults to single-line, unless minLines is set.
+    this.maxLines,
     this.minLines,
   });
 
@@ -50,7 +51,7 @@ class TextInput extends StatelessWidget {
       keyboardType: keyboardType,
       textCapitalization: textCapitalization,
       textAlign: textAlign,
-      maxLines: maxLines,
+      maxLines: maxLines ?? (minLines != null ? null : 1),
       minLines: minLines,
       style: textStyle,
       decoration: InputDecoration(

--- a/bindays_app/pubspec.yaml
+++ b/bindays_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.6.3+3
+version: 2.6.4+4
 
 environment:
   sdk: ^3.7.0

--- a/bindays_app/release_notes.json
+++ b/bindays_app/release_notes.json
@@ -1,10 +1,10 @@
 [
     {
         "language": "en-GB",
-        "text": "Reliability improvements for retrieving bin collection days across councils."
+        "text": "Improved the issue reporting flow with clearer guidance, including help for missed bin collections, plus device compatibility improvements."
     },
     {
         "language": "en-US",
-        "text": "Reliability improvements for retrieving bin collection days across councils."
+        "text": "Improved the issue reporting flow with clearer guidance, including help for missed bin collections, plus device compatibility improvements."
     }
 ]


### PR DESCRIPTION
Release **2.6.4+4**.

## Features
- **Bins not collected (#23):** new "Bins weren't collected" troubleshooting option leading to an informational page that explains BinDays isn't affiliated with the council and links to the council's website to report a missed collection directly.
- **Required issue description (#24):** the report-an-issue page now requires a free-text description before the email can be sent (replacing the `[Please describe your issue here]` placeholder users often left in). The council-website verification buttons were also reworded for clarity.

## Compatibility
- Android native libraries are now **16 KB page-size compatible** (required by Google Play for Android 15+). This is delivered via BinDays-Client (the `libcurl-impersonate.so` / `libc++_shared.so` bundled at build time are now 16 KB-aligned); no app code change was required. Verified on-device: the rebuilt libs report `0x4000` alignment and the app loads/refreshes correctly.

## Release housekeeping
- Bumped version to `2.6.4+4`.
- Updated `release_notes.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)