### PR TITLE
Release 2.6.5: Tip the Developer link in settings

### DIFF
--- a/bindays_app/lib/pages/settings_page.dart
+++ b/bindays_app/lib/pages/settings_page.dart
@@ -133,6 +133,18 @@ class _SettingsPageState extends State<SettingsPage> {
             ),
             ListTile(
               contentPadding: EdgeInsets.zero,
+              title: const Text('Leave a Tip'),
+              subtitle: const Text(
+                'Enjoying the app? Leave a tip if you\'d like to support development.',
+              ),
+              onTap:
+                  () => launchUrlString(
+                    "https://www.buymeacoffee.com/badgerhobbs",
+                    mode: LaunchMode.externalApplication,
+                  ),
+            ),
+            ListTile(
+              contentPadding: EdgeInsets.zero,
               title: const Text('Rate This App'),
               subtitle: const Text(
                 'Enjoying the app? Take a moment to rate it on the store.',

--- a/bindays_app/pubspec.yaml
+++ b/bindays_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.6.4+4
+version: 2.6.5+5
 
 environment:
   sdk: ^3.7.0

--- a/bindays_app/release_notes.json
+++ b/bindays_app/release_notes.json
@@ -1,10 +1,10 @@
 [
     {
         "language": "en-GB",
-        "text": "Improved the issue reporting flow with clearer guidance, including help for missed bin collections, plus device compatibility improvements."
+        "text": "You can now leave a tip from the Settings page to support development, if you'd like."
     },
     {
         "language": "en-US",
-        "text": "Improved the issue reporting flow with clearer guidance, including help for missed bin collections, plus device compatibility improvements."
+        "text": "You can now leave a tip from the Settings page to support development, if you'd like."
     }
 ]


### PR DESCRIPTION
## Summary

Implements #27 — adds a way to tip the developer from the settings page.

- Adds a **Leave a Tip** entry at the top of the **Feedback** section on the settings page, linking to the developer's [Buy Me a Coffee](https://www.buymeacoffee.com/badgerhobbs) page.
- The tip is framed as a voluntary gift with **nothing unlocked in return**, and opens in the **external browser** (`LaunchMode.externalApplication`) — keeping it within Apple and Google Play store guidelines for tips/donations (no digital content granted, so no IAP required).

## Release prep

- Bumped version `2.6.4+4` → `2.6.5+5` in `pubspec.yaml`.
- Updated `release_notes.json` (en-GB / en-US).

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)