### PR TITLE
Release 2.7.0: Group collections by bin

### DIFF
--- a/bindays_app/lib/data/models/bin_group.dart
+++ b/bindays_app/lib/data/models/bin_group.dart
@@ -1,0 +1,35 @@
+// External Imports
+import 'package:bindays_client/models/bin.dart';
+import 'package:bindays_client/models/bin_day.dart';
+
+/// Represents a bin and the next date it is collected on.
+class BinGroup {
+  /// The bin being collected.
+  final Bin bin;
+
+  /// The next date the bin is collected on.
+  final DateTime nextDate;
+
+  const BinGroup({required this.bin, required this.nextDate});
+
+  /// Flattens bin days into one group per bin, keeping only the earliest
+  /// (next) date for each, sorted soonest first then by name.
+  static List<BinGroup> fromBinDays(List<BinDay> binDays) {
+    final Map<String, BinGroup> groups = {};
+    for (final binDay in binDays) {
+      for (final bin in binDay.bins) {
+        final existing = groups[bin.name];
+        if (existing == null || binDay.date.isBefore(existing.nextDate)) {
+          groups[bin.name] = BinGroup(bin: bin, nextDate: binDay.date);
+        }
+      }
+    }
+
+    // Bins sharing a next date are common, so order those by name to keep
+    // the list stable between refreshes.
+    return groups.values.toList()..sort((a, b) {
+      final dateOrder = a.nextDate.compareTo(b.nextDate);
+      return dateOrder != 0 ? dateOrder : a.bin.name.compareTo(b.bin.name);
+    });
+  }
+}

--- a/bindays_app/lib/data/shared_preferences_manager.dart
+++ b/bindays_app/lib/data/shared_preferences_manager.dart
@@ -22,6 +22,7 @@ class SharedPreferencesManager {
   static const _isDarkModeKey = 'cachedIsDarkMode';
   static const _requestReviewAfterKey = 'requestReviewAfter';
   static const _showBinTypeIconsKey = 'showBinTypeIcons';
+  static const _groupByBinKey = 'groupByBin';
 
   static Future<void> loadSharedPreferences() async {
     if (_sharedPreferences != null) return;
@@ -197,5 +198,15 @@ class SharedPreferencesManager {
   /// Set show bin type icons in shared preferences.
   static Future<void> setShowBinTypeIcons(bool showBinTypeIcons) async {
     await _sharedPreferences?.setBool(_showBinTypeIconsKey, showBinTypeIcons);
+  }
+
+  /// Get group by bin from shared preferences.
+  static bool getGroupByBin() {
+    return _sharedPreferences?.getBool(_groupByBinKey) ?? false;
+  }
+
+  /// Set group by bin in shared preferences.
+  static Future<void> setGroupByBin(bool groupByBin) async {
+    await _sharedPreferences?.setBool(_groupByBinKey, groupByBin);
   }
 }

--- a/bindays_app/lib/extensions/bin_extension.dart
+++ b/bindays_app/lib/extensions/bin_extension.dart
@@ -1,0 +1,9 @@
+// External Imports
+import 'package:bindays_client/models/bin.dart';
+
+extension BinExtension on Bin {
+  /// Returns the bin colour and container type, e.g. "Brown Caddy".
+  String toTypeString() {
+    return "${colour.trim()} ${(type ?? "Bin").trim()}";
+  }
+}

--- a/bindays_app/lib/extensions/date_time_extension.dart
+++ b/bindays_app/lib/extensions/date_time_extension.dart
@@ -6,6 +6,10 @@ extension DateTimeExtension on DateTime {
     return "${DateFormat(DateFormat.WEEKDAY).format(this)}, $day ${DateFormat(DateFormat.MONTH).format(this)}";
   }
 
+  String toShortDateString() {
+    return "${DateFormat(DateFormat.ABBR_WEEKDAY).format(this)}, $day ${DateFormat(DateFormat.ABBR_MONTH).format(this)}";
+  }
+
   String daysUntilString() {
     final now = DateTime.now();
     final today = DateTime(now.year, now.month, now.day);

--- a/bindays_app/lib/notifiers/global_state_notifier.dart
+++ b/bindays_app/lib/notifiers/global_state_notifier.dart
@@ -19,6 +19,7 @@ class GlobalStateNotifier extends ChangeNotifier {
   DateTime? _lastRefresh;
   bool? _darkMode;
   bool? _showBinTypeIcons;
+  bool? _groupByBin;
 
   /// Reload all state from shared preferences.
   void reload() {
@@ -29,6 +30,7 @@ class GlobalStateNotifier extends ChangeNotifier {
     _reloadLastRefresh();
     _reloadDarkMode();
     _reloadShowBinTypeIcons();
+    _reloadGroupByBin();
   }
 
   /// Notify listeners and reschedule notifications.
@@ -149,6 +151,22 @@ class GlobalStateNotifier extends ChangeNotifier {
   Future<void> setShowBinTypeIcons(bool showBinTypeIcons) async {
     _showBinTypeIcons = showBinTypeIcons;
     await SharedPreferencesManager.setShowBinTypeIcons(showBinTypeIcons);
+    notifyListeners();
+  }
+
+  /// Get current group by bin.
+  bool get groupByBin => _groupByBin ?? false;
+
+  /// Reload group by bin from shared preferences.
+  void _reloadGroupByBin() {
+    _groupByBin = SharedPreferencesManager.getGroupByBin();
+    notifyListeners();
+  }
+
+  /// Set group by bin in shared preferences.
+  Future<void> setGroupByBin(bool groupByBin) async {
+    _groupByBin = groupByBin;
+    await SharedPreferencesManager.setGroupByBin(groupByBin);
     notifyListeners();
   }
 }

--- a/bindays_app/lib/pages/settings_page.dart
+++ b/bindays_app/lib/pages/settings_page.dart
@@ -89,6 +89,16 @@ class _SettingsPageState extends State<SettingsPage> {
                 'Show bin type icons instead of the default icon.',
               ),
             ),
+            SwitchListTile(
+              contentPadding: EdgeInsets.zero,
+              value: globalStateNotifier.groupByBin,
+              onChanged: (val) => globalStateNotifier.setGroupByBin(val),
+              title: const Text('Group by Bin'),
+              subtitle: const Text(
+                'Show each bin\'s next collection date, when only one date '
+                'per bin is shown.',
+              ),
+            ),
             const SizedBox(height: 20),
             Text('Source Code', style: Theme.of(context).textTheme.titleMedium),
             ListTile(

--- a/bindays_app/lib/widgets/bin_days/bin_day_list_item.dart
+++ b/bindays_app/lib/widgets/bin_days/bin_day_list_item.dart
@@ -3,16 +3,13 @@ import 'package:bindays_client/models/bin.dart';
 import 'package:flutter/material.dart';
 
 // Internal Imports
+import 'package:bindays_app/extensions/bin_extension.dart';
 import 'package:bindays_app/widgets/bin_days/bin_icon.dart';
 
 class BinDayListItem extends StatelessWidget {
   final Bin bin;
 
   const BinDayListItem({super.key, required this.bin});
-
-  String _getBinType() {
-    return "${bin.colour.trim()} ${bin.type ?? "Bin".trim()}";
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -28,7 +25,7 @@ class BinDayListItem extends StatelessWidget {
         ),
       ),
       subtitle: Text(
-        _getBinType(),
+        bin.toTypeString(),
         style: TextStyle(
           fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
           color: Theme.of(context).colorScheme.onSurfaceVariant,

--- a/bindays_app/lib/widgets/bin_days/bin_days_found.dart
+++ b/bindays_app/lib/widgets/bin_days/bin_days_found.dart
@@ -4,8 +4,10 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 // Internal Imports
+import 'package:bindays_app/notifiers/global_notifiers.dart';
 import 'package:bindays_app/widgets/bin_days/bin_day_groups.dart';
 import 'package:bindays_app/widgets/bin_days/bin_day_header.dart';
+import 'package:bindays_app/widgets/bin_days/bin_groups.dart';
 
 class BinDaysFound extends StatelessWidget {
   final List<BinDay> _binDays;
@@ -27,7 +29,9 @@ class BinDaysFound extends StatelessWidget {
         children: [
           BinDayHeader(binDay: _binDays.first),
           const SizedBox(height: 25),
-          BinDayGroups(binDays: _binDays),
+          globalStateNotifier.groupByBin
+              ? BinGroups(binDays: _binDays)
+              : BinDayGroups(binDays: _binDays),
           const SizedBox(height: 25),
           Text(
             "Refreshed on ${DateFormat("dd/MM/yyyy").format(_lastRefresh)} at ${DateFormat("HH:mm").format(_lastRefresh)}",

--- a/bindays_app/lib/widgets/bin_days/bin_group_list_item.dart
+++ b/bindays_app/lib/widgets/bin_days/bin_group_list_item.dart
@@ -1,0 +1,58 @@
+// External Imports
+import 'package:flutter/material.dart';
+
+// Internal Imports
+import 'package:bindays_app/data/models/bin_group.dart';
+import 'package:bindays_app/extensions/bin_extension.dart';
+import 'package:bindays_app/extensions/date_time_extension.dart';
+import 'package:bindays_app/widgets/bin_days/bin_icon.dart';
+
+class BinGroupListItem extends StatelessWidget {
+  final BinGroup binGroup;
+
+  const BinGroupListItem({super.key, required this.binGroup});
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      dense: true,
+      visualDensity: VisualDensity.compact,
+      contentPadding: EdgeInsets.zero,
+      leading: BinIcon(bin: binGroup.bin),
+      title: Text(
+        binGroup.bin.name,
+        style: TextStyle(
+          fontSize: Theme.of(context).textTheme.bodyLarge!.fontSize,
+        ),
+      ),
+      subtitle: Text(
+        binGroup.bin.toTypeString(),
+        style: TextStyle(
+          fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+          color: Theme.of(context).colorScheme.onSurfaceVariant,
+        ),
+      ),
+      trailing: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            binGroup.nextDate.toShortDateString(),
+            textAlign: TextAlign.end,
+            style: TextStyle(
+              fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          Text(
+            binGroup.nextDate.daysUntilString(),
+            style: TextStyle(
+              fontSize: Theme.of(context).textTheme.bodyMedium!.fontSize,
+              color: Theme.of(context).colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/bindays_app/lib/widgets/bin_days/bin_groups.dart
+++ b/bindays_app/lib/widgets/bin_days/bin_groups.dart
@@ -1,0 +1,25 @@
+// External Imports
+import 'package:bindays_client/models/bin_day.dart';
+import 'package:flutter/material.dart';
+
+// Internal Imports
+import 'package:bindays_app/data/models/bin_group.dart';
+import 'package:bindays_app/widgets/bin_days/bin_group_list_item.dart';
+
+class BinGroups extends StatelessWidget {
+  final List<BinDay> binDays;
+
+  const BinGroups({super.key, required this.binDays});
+
+  @override
+  Widget build(BuildContext context) {
+    final binGroups = BinGroup.fromBinDays(binDays);
+
+    return Column(
+      children:
+          binGroups
+              .map((binGroup) => BinGroupListItem(binGroup: binGroup))
+              .toList(),
+    );
+  }
+}

--- a/bindays_app/pubspec.yaml
+++ b/bindays_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: "none" # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.6.5+5
+version: 2.7.0+1
 
 environment:
   sdk: ^3.7.0

--- a/bindays_app/release_notes.json
+++ b/bindays_app/release_notes.json
@@ -1,10 +1,10 @@
 [
     {
         "language": "en-GB",
-        "text": "You can now leave a tip from the Settings page to support development, if you'd like."
+        "text": "You can now group your collections by bin from the Settings page, showing each bin alongside its next collection date."
     },
     {
         "language": "en-US",
-        "text": "You can now leave a tip from the Settings page to support development, if you'd like."
+        "text": "You can now group your collections by bin from the Settings page, showing each bin alongside its next collection date."
     }
 ]


### PR DESCRIPTION
## Summary

Implements #29 — adds an opt-in setting to group the collections list by bin rather than by date.

- Adds a **Group by Bin** switch to the **General** section of the settings page, defaulting to **off** so the existing date-grouped view is unchanged unless enabled.
- When enabled, the collections list shows **one row per bin** with that bin's next collection date, in place of the one-group-per-date layout.
- Some collectors only return the *next* collection date for each bin. Grouped by date the list reads as a complete schedule, so a weekly bin absent from a later date group looks like incorrect data rather than an absence of data. Grouping by bin removes that reading.

## Notes

- Extracts the duplicated bin colour/type string into a `Bin.toTypeString()` extension. This corrects a misplaced `.trim()` which applied to the `"Bin"` fallback literal rather than the value — so a collector returning a padded `type` no longer renders a double space in the **existing** date-grouped list. Minor, but it is a behaviour change outside the new feature.
- Adds `DateTime.toShortDateString()` ("Wed, 12 Aug"), used only in the new rows. `ListTile` gives `trailing` layout priority, so the full-length date left long bin names (e.g. "Non-recyclable waste (grey bin)") around 117px on a 360dp screen.
- Grouping keys on `bin.name`, matching the API, which already de-duplicates with `DistinctBy(b => b.Name)`.

## Release prep

- Bumped version `2.6.5+5` → `2.7.0+1` in `pubspec.yaml`. Build number returns to `+1` — the convention used through 2.6.1 — as nothing in the repo consumes it.
- Updated `release_notes.json` (en-GB / en-US).

## Testing

`flutter analyze` passes with no issues. **Not yet exercised on a device** — the web target cannot build (`dart:ffi`) and the Windows desktop build fails locally for unrelated environment reasons. The layout is worth a visual check before release, particularly a long bin name in the new rows.

Closes #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)